### PR TITLE
Remove references (in prose and code) to javascript

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # pdxgit.github.com website
 
-This is the code behind http://pdxgit.com (AKA http://pdxgit.github.com ) . Patches welcome :)
+This is the code behind http://pdxgit.com (AKA http://pdxgit.github.com). Patches welcome :)
 
-This site is powered by Jekyll, Twitter Bootstrap, Font Awesome and jQuery.
+This site is powered by Jekyll, Twitter Bootstrap, and Font Awesome.

--- a/_includes/_head.html
+++ b/_includes/_head.html
@@ -1,8 +1,6 @@
 <head>
   <meta http-equiv='Content-Type' content='text/html; charset=utf-8' />
   <!--[if lt IE 9]><script type='text/javascript' src='/assets/javascript/html5.js'></script><![endif]-->
-  <script type='text/javascript' src='//ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js'></script>
-  <script type='text/javascript' src='/assets/vendor/bootstrap/js/bootstrap.min.js'></script>
   <link rel='stylesheet' type='text/css' href='/assets/css/screen.css' />
   <link rel='stylesheet' type='text/css' href='/assets/vendor/bootstrap/css/bootstrap.min.css' />
   <link rel='stylesheet' type='text/css' href='/assets/vendor/font-awesome/css/font-awesome.min.css' />


### PR DESCRIPTION
Thanks for reminding me (79e8462b3) that the new site uses no
javascript, unless you are on IE < v9 and invoke the shim.

I've left the libraries under assets/vendor intact, so it can be easy to
use other features in the future, and easier to upgrade the libraries.
