### PR TITLE
Use `layout: null` instead of `layout: nil`

### DIFF
--- a/atom.xml
+++ b/atom.xml
@@ -1,5 +1,5 @@
 ---
-layout: nil
+layout: null
 ---
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">


### PR DESCRIPTION
Apparently this is the right way to do it (https://github.com/jekyll/jekyll/issues/2712) and Jekyll shows a warning if it is set to `nil`.
