### PR TITLE
Change `pygments` option to `highlighter`

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 markdown: rdiscount
-pygments: true
+highlighter: pygments
 exclude:
   - config.ru
   - Gemfile


### PR DESCRIPTION
The 'pygments' configuration option has been renamed to 'highlighter'.
